### PR TITLE
Remove pre-install script

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-mailtrap",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "n8n node for Mailtrap integration (send email, manage contacts)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "url": "https://github.com/railsware/mailtrap-n8n"
   },
   "scripts": {
-    "preinstall": "npx only-allow pnpm",
     "build": "tsc && gulp build:icons",
     "dev": "tsc --watch",
     "format": "prettier nodes --write",


### PR DESCRIPTION
Addressing n8n team request: 
- Please remove the preinstall script from package.json to comply with n8n community node security requirements


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package version to 1.1.4.
  * Removed enforcement of pnpm as the required package manager during installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->