### PR TITLE
update readme with mentioning Cloud version

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ For n8n version 0.187 and later, you can install this node through the Community
 4. Agree to the risks of using community nodes
 5. Select Install
 
+### n8n Cloud
+If you're using [n8n Cloud](https://cloud.n8n.io/), the Mailtrap node is available out of the box. Simply search for "Mailtrap" in the node library when building your workflows.
+
 ### Manual Installation
 Alternatively, you can install the node manually using one of these methods:
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added information to the README about the Mailtrap node being pre-installed and available by default in n8n Cloud, with guidance on how to find it in the node library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->