### PR TITLE
Implement draft-release workflow

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -79,7 +79,6 @@ jobs:
           next: ${{ steps.bump.outputs.next }}
           bump-type: ${{ inputs.bump_type }}
           release-notes: ${{ steps.notes.outputs.release_notes }}
-          files: package.json CHANGELOG.md
 
       - name: Create draft GitHub release
         if: steps.notes.outputs.release_notes != ''

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,4 +1,5 @@
-# Placeholder draft-release workflow
+# Drafts new mailtrap-n8n release: bumps the version, regenerates the changelog from
+# merged PRs, and opens a release PR against main.
 #
 name: Draft n8n Release
 on:
@@ -14,14 +15,75 @@ on:
           - major
         default: patch
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   draft-release:
-    name: Draft n8n Release (placeholder)
+    name: Draft mailtrap-n8n Release
     runs-on: ubuntu-latest
     steps:
-      - name: Echo inputs
-        env:
-          BUMP_TYPE: ${{ inputs.bump_type }}
-        run: |
-          echo "Placeholder draft-release workflow"
-          echo "bump_type=$BUMP_TYPE"
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .tool-versions
+
+      - name: Read current version
+        id: read
+        uses: railsware/github-actions/read-version-from-package-json@master
+
+      - name: Compute next version
+        id: bump
+        uses: railsware/github-actions/compute-next-semver@master
+        with:
+          current: ${{ steps.read.outputs.version }}
+          bump-type: ${{ inputs.bump_type }}
+
+      - name: Abort if tag already exists
+        uses: railsware/github-actions/abort-if-tag-exists@master
+        with:
+          tag: ${{ steps.bump.outputs.tag }}
+
+      - name: Generate release notes
+        id: notes
+        uses: railsware/github-actions/generate-release-notes@master
+        with:
+          tag: ${{ steps.bump.outputs.tag }}
+
+      - name: Update version in package.json
+        if: steps.notes.outputs.release_notes != ''
+        run: npm version "${{ steps.bump.outputs.next }}" --no-git-tag-version
+
+      - name: Prepend new section to CHANGELOG.md
+        if: steps.notes.outputs.release_notes != ''
+        uses: railsware/github-actions/prepend-changelog@master
+        with:
+          version: ${{ steps.bump.outputs.next }}
+          release-notes: ${{ steps.notes.outputs.release_notes }}
+
+      - name: Commit, push, open PR
+        if: steps.notes.outputs.release_notes != ''
+        uses: railsware/github-actions/open-sdk-release-pr@master
+        with:
+          tag: ${{ steps.bump.outputs.tag }}
+          current: ${{ steps.read.outputs.version }}
+          next: ${{ steps.bump.outputs.next }}
+          bump-type: ${{ inputs.bump_type }}
+          release-notes: ${{ steps.notes.outputs.release_notes }}
+          files: package.json CHANGELOG.md
+
+      - name: Create draft GitHub release
+        if: steps.notes.outputs.release_notes != ''
+        uses: railsware/github-actions/create-draft-github-release@master
+        with:
+          tag: ${{ steps.bump.outputs.tag }}
+          release-notes: ${{ steps.notes.outputs.release_notes }}


### PR DESCRIPTION
## Motivation


## Changes

- Implement "Draft n8n Release" workflow

## How to test


### Success case
- [ ] Trigger "Draft n8n Release" workflow
- [ ] Assert new release PR opened 
- [ ] Assert draft github release created

### Nothing to release case
- [ ] Trigger "Draft n8n Release" workflow
- [ ] Assert no new release PR
- [ ] Assert no draft github release created

## Images and GIFs

<img width="2596" height="1218" alt="image" src="https://github.com/user-attachments/assets/78d87e0b-6735-47c5-8ff2-c17b4c95d7bc" />
<img width="1880" height="1522" alt="image" src="https://github.com/user-attachments/assets/644b577d-6440-41de-81a3-d5dcae082004" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved the release process to automatically draft releases with version updates, generated release notes, and a draft release entry.
  * Added safeguards to prevent creating duplicate releases when the target version/tag already exists.
  * Updated the workflow to only publish a draft when meaningful release notes are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->