### PR TITLE
MT-22678: add Search field to Get Contact Lists

### DIFF
--- a/nodes/Mailtrap/actions/contact/getLists.operation.ts
+++ b/nodes/Mailtrap/actions/contact/getLists.operation.ts
@@ -9,6 +9,7 @@ import { mailtrapFields } from "../mailtrapFields";
 
 const properties: INodeProperties[] = [
   mailtrapFields.accountId,
+  mailtrapFields.search,
 ];
 
 const displayOptions = {
@@ -28,7 +29,15 @@ export async function execute(
   const transport = new MailtrapTransport(this);
 
   const accountId = this.getNodeParameter('accountId', item) as string;
-  const responseData = await transport.request('GET', `/accounts/${accountId}/contacts/lists`);
+  const search = this.getNodeParameter('search', item, '') as string;
+
+  const responseData = await transport.request(
+    'GET',
+    `/accounts/${accountId}/contacts/lists`,
+    {},
+    undefined,
+    search ? { search } : {},
+  );
 
   data.push({ json: responseData, pairedItem: { item } });
 

--- a/nodes/Mailtrap/actions/mailtrapFields.ts
+++ b/nodes/Mailtrap/actions/mailtrapFields.ts
@@ -3,6 +3,7 @@ import { INodeProperties } from 'n8n-workflow';
 export interface MailtrapFields extends Record<
   | "accountId"
   | "idOrEmail"
+  | "search"
   | "fromName"
   | "fromEmail"
   | "replyToName"
@@ -168,6 +169,18 @@ export const mailtrapFields: MailtrapFields = {
     type: 'boolean',
     default: false,
     description: 'Whether the contact is unsubscribed',
+  },
+
+  // ---------------------------------------------------
+  //                  Contact Lists
+  // ---------------------------------------------------
+  search: {
+    displayName: 'Search',
+    name: 'search',
+    type: 'string',
+    default: '',
+    description: 'Filter contact lists by name',
+    placeholder: 'e.g. news',
   },
 
   // ---------------------------------------------------

--- a/nodes/Mailtrap/transport/index.ts
+++ b/nodes/Mailtrap/transport/index.ts
@@ -16,6 +16,7 @@ export class MailtrapTransport {
    * @param endpoint
    * @param body
    * @param host
+   * @param qs
    * @throws NodeApiError
    */
   async request(
@@ -23,6 +24,7 @@ export class MailtrapTransport {
     endpoint: string,
     body: IDataObject = {},
     host?: string,
+    qs: IDataObject = {},
   ): Promise<any> {
     const options: IHttpRequestOptions = {
       method,
@@ -35,6 +37,7 @@ export class MailtrapTransport {
       },
       json: true as const,
       body: Object.keys(body).length ? body : undefined,
+      qs: Object.keys(qs).length ? qs : undefined,
     };
 
     try {


### PR DESCRIPTION
## Motivation

https://railsware.atlassian.net/browse/MT-22678

## Changes

- Add an optional `Search` field to the Contact → Get Contact Lists operation — filters lists by name, per the OpenAPI `GET /api/contacts/lists` param. Sent only when non-empty, so existing workflows are unchanged.
  - `MailtrapTransport.request` gains a trailing `qs` argument (no query-param support existed before); positional callers are unaffected.

## How to test

- [ ] Contact → Get Contact Lists with Search empty — returns all contact lists (unchanged behaviour).
- [ ] Contact → Get Contact Lists with Search = "news" — returns only lists whose name starts with "news" (case-insensitive).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional search field to the contact lists operation.
  * Contact lists can now be filtered by name using the search term.
  * Search criteria are included in requests only when provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->